### PR TITLE
[DOC] Update Installation index.rst

### DIFF
--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -15,14 +15,14 @@ If your TYPO3 installation works in composer mode, please execute following comm
 ..  code-block:: bash
 
     composer req jweiland/like-it
-    vendor/bin/typo3 extension:setup --extension=like-it
+    vendor/bin/typo3 extension:setup --extension=like_it
 
 If you work with DDEV please execute this command:
 
 ..  code-block:: bash
 
     ddev composer req jweiland/like-it
-    ddev exec vendor/bin/typo3 extension:setup --extension=like-it
+    ddev exec vendor/bin/typo3 extension:setup --extension=like_it
 
 ExtensionManager
 ================


### PR DESCRIPTION
Hi seems a small typo in extension:setup, should be extension Name.
Testet in TYPO3 v11, if i use:

`ddev exec vendor/bin/typo3 extension:setup --extension=like-it`

i got:
` [ERROR] Given extensions "like-it" not found in the system. `

this is working:
`ddev exec vendor/bin/typo3 extension:setup --extension=like_it`