### PR TITLE
[TASK] css in backend controller

### DIFF
--- a/Classes/Controller/LikeModuleController.php
+++ b/Classes/Controller/LikeModuleController.php
@@ -13,7 +13,8 @@ namespace JWeiland\LikeIt\Controller;
 
 use JWeiland\LikeIt\Domain\Repository\LikeRepository;
 use JWeiland\LikeIt\Service\LikedTableService;
-use TYPO3\CMS\Backend\View\BackendTemplateView;
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
 
 /**
@@ -21,11 +22,6 @@ use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
  */
 class LikeModuleController extends ActionController
 {
-    /**
-     * @var BackendTemplateView
-     */
-    protected $view;
-
     /**
      * @var LikeRepository
      */
@@ -45,8 +41,15 @@ class LikeModuleController extends ActionController
     {
         $this->likedTableService = $likedTableService;
     }
+    protected ModuleTemplateFactory $moduleTemplateFactory;
 
-    public function listAction(string $table = ''): void
+    public function __construct(
+        ModuleTemplateFactory $moduleTemplateFactory
+    ) {
+        $this->moduleTemplateFactory = $moduleTemplateFactory;
+    }
+
+    public function listAction(string $table = ''): ResponseInterface
     {
         $likedTables = $this->likedTableService->getArrayForTableSelection();
         $this->view->assign('likedTables', $likedTables);
@@ -60,5 +63,8 @@ class LikeModuleController extends ActionController
         if ($table) {
             $this->view->assign('likedTableItems', $this->likeRepository->findLikedTableItems($table));
         }
+        $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
+        $moduleTemplate->setContent($this->view->render());
+        return $this->htmlResponse($moduleTemplate->renderContent());
     }
 }

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -15,14 +15,14 @@ If your TYPO3 installation works in composer mode, please execute following comm
 ..  code-block:: bash
 
     composer req jweiland/like-it
-    vendor/bin/typo3 extension:setup --extension=like_it
+    vendor/bin/typo3 extension:setup --extension=like-it
 
 If you work with DDEV please execute this command:
 
 ..  code-block:: bash
 
     ddev composer req jweiland/like-it
-    ddev exec vendor/bin/typo3 extension:setup --extension=like_it
+    ddev exec vendor/bin/typo3 extension:setup --extension=like-it
 
 ExtensionManager
 ================

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -15,14 +15,14 @@ If your TYPO3 installation works in composer mode, please execute following comm
 ..  code-block:: bash
 
     composer req jweiland/like-it
-    vendor/bin/typo3 extension:setup --extension=like-it
+    vendor/bin/typo3 extension:setup --extension=like_it
 
 If you work with DDEV please execute this command:
 
 ..  code-block:: bash
 
     ddev composer req jweiland/like-it
-    ddev exec vendor/bin/typo3 extension:setup --extension=like-it
+    ddev exec vendor/bin/typo3 extension:setup --extension=like_it
 
 ExtensionManager
 ================


### PR DESCRIPTION
hi @froemken 

It seems that no CSS is loaded in the backend module of the extension, see attachment. I have integrated the default CSS in TYPO3 11 as described [here](https://docs.typo3.org/m/typo3/reference-coreapi/11.5/en-us/ExtensionArchitecture/HowTo/BackendModule/BackendModulesWithExtbase/BackendTemplateViewWithExtbase.html), but this way is not compatible with TYPO3 10.
Since the TYPO3 support for the 10 was officially discontinued, the question would be whether one should make there also still adjustments?

<img width="981" alt="Bildschirmfoto 2023-06-06 um 15 44 41" src="https://github.com/jweiland-net/like_it/assets/20923295/0e2953aa-ff52-4c58-8e81-40c5bb3113e9">

