### PR TITLE
[TASK] typo in language label

### DIFF
--- a/Resources/Private/Partials/Rating.html
+++ b/Resources/Private/Partials/Rating.html
@@ -9,7 +9,7 @@
 <div class="tx-likeit-container"
 		 data-table="{table}"
 		 data-uid="{uid}"
-		 data-message-like="{f:translate(key: 'message.not_liked', extensionName: 'LikeIt')}"
+		 data-message-like="{f:translate(key: 'message.liked', extensionName: 'LikeIt')}"
 		 data-message-no-like="{f:translate(key: 'message.not_liked', extensionName: 'LikeIt')}">
 	<a href="#like" class="btn btn-default tx-likeit-like">
 		<f:render section="renderIcon"/>


### PR DESCRIPTION
hi @froemken,

there is a typo in the message label for "like" and "not_like"